### PR TITLE
foodpornメソッドを飯テロ専用に固定

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ Create `config.json` file and specifies it at execute using this template:
     },
     "command": {
         "foodporn": {
-            "trigger": [
-                "tired"
-            ],
-            "keywords": [
-                "food porn"
-            ],
             "messages": [
                 "cheer up"
             ]

--- a/command/command.go
+++ b/command/command.go
@@ -23,9 +23,9 @@ type Config struct {
 }
 
 type BotCommand struct {
-	Trg  []string `json:"trigger"`
-	Kws  []string `json:"keywords"`
-	Msgs []string `json:"messages"`
+	Trigger  []string `json:"trigger"`
+	Keywords []string `json:"keywords"`
+	Messages []string `json:"messages"`
 }
 
 func init() {
@@ -65,19 +65,19 @@ func (cfg *Config) sendImage(s *discordgo.Session, c *discordgo.Channel, keyword
 }
 
 func (cfg *Config) foodPornKeyword() (string, error) {
-	return any(cfg.Command.FoodPorn.Kws)
+	return any(cfg.Command.FoodPorn.Keywords)
 }
 
 func (cfg *Config) foodPornMessage() (string, error) {
-	return any(cfg.Command.FoodPorn.Msgs)
+	return any(cfg.Command.FoodPorn.Messages)
 }
 
 func (cfg *Config) WelcomeKeyword() (string, error) {
-	return any(cfg.Command.Welcome.Kws)
+	return any(cfg.Command.Welcome.Keywords)
 }
 
 func (cfg *Config) welcomeMessage() (string, error) {
-	return any(cfg.Command.Welcome.Msgs)
+	return any(cfg.Command.Welcome.Messages)
 }
 
 func any(target []string) (string, error) {

--- a/command/command.go
+++ b/command/command.go
@@ -72,7 +72,7 @@ func (cfg *Config) foodPornMessage() (string, error) {
 	return any(cfg.Command.FoodPorn.Messages)
 }
 
-func (cfg *Config) WelcomeKeyword() (string, error) {
+func (cfg *Config) welcomeKeyword() (string, error) {
 	return any(cfg.Command.Welcome.Keywords)
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -23,7 +23,6 @@ type Config struct {
 }
 
 type BotCommand struct {
-	Trigger  []string `json:"trigger"`
 	Keywords []string `json:"keywords"`
 	Messages []string `json:"messages"`
 }
@@ -62,10 +61,6 @@ func (cfg *Config) sendImage(s *discordgo.Session, c *discordgo.Channel, keyword
 	if err != nil {
 		errr.Printf("%s\n", err)
 	}
-}
-
-func (cfg *Config) foodPornKeyword() (string, error) {
-	return any(cfg.Command.FoodPorn.Keywords)
 }
 
 func (cfg *Config) foodPornMessage() (string, error) {

--- a/command/foodporn.go
+++ b/command/foodporn.go
@@ -14,12 +14,12 @@ const (
 )
 
 func (cfg *Config) FoodPorn(s *discordgo.Session, m *discordgo.MessageCreate) {
-	if len(cfg.Command.FoodPorn.Trg) == 0 {
+	if len(cfg.Command.FoodPorn.Trigger) == 0 {
 		errr.Printf("No configuration")
 		return
 	}
 
-	for _, trg := range cfg.Command.FoodPorn.Trg {
+	for _, trg := range cfg.Command.FoodPorn.Trigger {
 		if strings.Contains(m.Content, trg) {
 			user := m.Author
 			if user.Username == cfg.Discord.UserName || user.Bot {

--- a/command/foodporn.go
+++ b/command/foodporn.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"math/rand"
 	"strings"
 	"time"
 
@@ -9,17 +10,27 @@ import (
 )
 
 const (
-	dfk = "food porn"
 	dfm = "Take it easy"
 )
 
-func (cfg *Config) FoodPorn(s *discordgo.Session, m *discordgo.MessageCreate) {
-	if len(cfg.Command.FoodPorn.Trigger) == 0 {
-		errr.Printf("No configuration")
-		return
+var (
+	fptrg = []string{
+		"疲",
+		"つかれ",
 	}
+	fpkws = []string{
+		"飯テロ",
+		"飯テロ 肉",
+		"飯テロ 刺身",
+		"飯テロ ステーキ",
+		"飯テロ ラーメン",
+		"飯テロ ジャンクフード",
+		"飯テロ スイーツ",
+	}
+)
 
-	for _, trg := range cfg.Command.FoodPorn.Trigger {
+func (cfg *Config) FoodPorn(s *discordgo.Session, m *discordgo.MessageCreate) {
+	for _, trg := range fptrg {
 		if strings.Contains(m.Content, trg) {
 			user := m.Author
 			if user.Username == cfg.Discord.UserName || user.Bot {
@@ -38,11 +49,8 @@ func (cfg *Config) FoodPorn(s *discordgo.Session, m *discordgo.MessageCreate) {
 			}
 			sendMessage(s, c, msg)
 
-			kw, err := cfg.foodPornKeyword()
-			if err != nil {
-				kw = dfk
-			}
-			cfg.sendImage(s, c, kw)
+			max := len(fpkws)
+			cfg.sendImage(s, c, fpkws[rand.Intn(max)])
 			return
 		}
 	}
@@ -86,11 +94,8 @@ func (cfg *Config) HeadsUp(s *discordgo.Session, p *discordgo.PresenceUpdate) {
 					msg := u.Mention() + "、あなた疲れてるのよ\n"
 					sendMessage(s, c, msg)
 
-					kw, err := cfg.foodPornKeyword()
-					if err != nil {
-						kw = dfk
-					}
-					cfg.sendImage(s, c, kw)
+					max := len(fpkws)
+					cfg.sendImage(s, c, fpkws[rand.Intn(max)])
 				}
 			}
 		}

--- a/command/welcome.go
+++ b/command/welcome.go
@@ -28,7 +28,7 @@ func (cfg *Config) Welcome(s *discordgo.Session, p *discordgo.PresenceUpdate) {
 			msg := p.User.Mention() + "\t" + wm
 			sendMessage(s, c, msg)
 
-			wk, err := cfg.WelcomeKeyword()
+			wk, err := cfg.welcomeKeyword()
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
発動条件および検索ワードが可変だとfoodpornメソッドである意味がないので、飯テロ専門となるように内部で固定