### PR TITLE
ログアウト後もheads-upが実行され続ける問題を修正

### DIFF
--- a/command/welcome.go
+++ b/command/welcome.go
@@ -18,7 +18,7 @@ func (bot *Bot) Welcome(session disgord.Session, evt *disgord.PresenceUpdate) {
 	if evt.Status == "online" && lc == nil {
 		bot.loginChans[evt.User.ID] = make(chan struct{})
 		bot.welcome(session, evt)
-		bot.headsup(session, evt)
+		go bot.headsup(session, evt)
 	}
 
 	if evt.Status == "offline" && lc != nil {


### PR DESCRIPTION
discordgoでは`AddHandler`に追加した関数がgoroutineで呼ばれていたが、disgordの`On`はそのまま直列で実行されるため、`headsup`がdead lockしまい`PresenceUpdate`イベントが取得できなくなってしまっていた。

`headsup`をgoroutineで実行することで回避